### PR TITLE
SystemUI: QS: keep emergency call only text consistent

### DIFF
--- a/packages/SystemUI/res/values-en-rAU/strings.xml
+++ b/packages/SystemUI/res/values-en-rAU/strings.xml
@@ -325,7 +325,7 @@
     <string name="quick_settings_location_off_label" msgid="7464544086507331459">"Location Off"</string>
     <string name="quick_settings_media_device_label" msgid="1302906836372603762">"Media device"</string>
     <string name="quick_settings_rssi_label" msgid="7725671335550695589">"RSSI"</string>
-    <string name="quick_settings_rssi_emergency_only" msgid="2713774041672886750">"Emergency Calls Only"</string>
+    <string name="quick_settings_rssi_emergency_only" msgid="2713774041672886750">"Emergency calls only"</string>
     <string name="quick_settings_settings_label" msgid="5326556592578065401">"Settings"</string>
     <string name="quick_settings_time_label" msgid="4635969182239736408">"Time"</string>
     <string name="quick_settings_user_label" msgid="5238995632130897840">"Me"</string>

--- a/packages/SystemUI/res/values-en-rGB/strings.xml
+++ b/packages/SystemUI/res/values-en-rGB/strings.xml
@@ -325,7 +325,7 @@
     <string name="quick_settings_location_off_label" msgid="7464544086507331459">"Location Off"</string>
     <string name="quick_settings_media_device_label" msgid="1302906836372603762">"Media device"</string>
     <string name="quick_settings_rssi_label" msgid="7725671335550695589">"RSSI"</string>
-    <string name="quick_settings_rssi_emergency_only" msgid="2713774041672886750">"Emergency Calls Only"</string>
+    <string name="quick_settings_rssi_emergency_only" msgid="2713774041672886750">"Emergency calls only"</string>
     <string name="quick_settings_settings_label" msgid="5326556592578065401">"Settings"</string>
     <string name="quick_settings_time_label" msgid="4635969182239736408">"Time"</string>
     <string name="quick_settings_user_label" msgid="5238995632130897840">"Me"</string>

--- a/packages/SystemUI/res/values-en-rIN/strings.xml
+++ b/packages/SystemUI/res/values-en-rIN/strings.xml
@@ -325,7 +325,7 @@
     <string name="quick_settings_location_off_label" msgid="7464544086507331459">"Location Off"</string>
     <string name="quick_settings_media_device_label" msgid="1302906836372603762">"Media device"</string>
     <string name="quick_settings_rssi_label" msgid="7725671335550695589">"RSSI"</string>
-    <string name="quick_settings_rssi_emergency_only" msgid="2713774041672886750">"Emergency Calls Only"</string>
+    <string name="quick_settings_rssi_emergency_only" msgid="2713774041672886750">"Emergency calls only"</string>
     <string name="quick_settings_settings_label" msgid="5326556592578065401">"Settings"</string>
     <string name="quick_settings_time_label" msgid="4635969182239736408">"Time"</string>
     <string name="quick_settings_user_label" msgid="5238995632130897840">"Me"</string>

--- a/packages/SystemUI/res/values/strings.xml
+++ b/packages/SystemUI/res/values/strings.xml
@@ -788,7 +788,7 @@
     <!-- QuickSettings: RSSI [CHAR LIMIT=NONE] -->
     <string name="quick_settings_rssi_label">RSSI</string>
     <!-- QuickSettings: RSSI (No network) [CHAR LIMIT=NONE] -->
-    <string name="quick_settings_rssi_emergency_only">Emergency Calls Only</string>
+    <string name="quick_settings_rssi_emergency_only">Emergency calls only</string>
     <!-- QuickSettings: Settings [CHAR LIMIT=NONE] -->
     <string name="quick_settings_settings_label">Settings</string>
     <!-- QuickSettings: Time [CHAR LIMIT=NONE] -->


### PR DESCRIPTION
In QS header it is written like "Emergency calls only", but
on the QS tile it is written like "Emergency Calls Only".

Fix up this inconsistency.

Test: None.

Change-Id: I2ff2c52f7fa663bcf619a6a949760ad2177fbb77
Signed-off-by: Simao Gomes Viana <xdevs23@outlook.com>