### PR TITLE
ViewRootImpl: set max fling ticks per sec to 24 

### DIFF
--- a/core/java/android/view/ViewRootImpl.java
+++ b/core/java/android/view/ViewRootImpl.java
@@ -6372,7 +6372,7 @@ public final class ViewRootImpl implements ViewParent,
         // probably not be set to anything less than about 4.
         // If fling accuracy is a problem then consider tuning the tick distance instead.
         private static final float MIN_FLING_VELOCITY_TICKS_PER_SECOND = 6f;
-        private static final float MAX_FLING_VELOCITY_TICKS_PER_SECOND = 20f;
+        private static final float MAX_FLING_VELOCITY_TICKS_PER_SECOND = 24f;
 
         // Fling velocity decay factor applied after each new key is emitted.
         // This parameter controls the deceleration and overall duration of the fling.


### PR DESCRIPTION
makes scrolling appear smoother for devices that dont have the fine-tuned props like this: https://github.com/halogenOS/android_device_oneplus_msm8998-common/commit/25bada807c8f2a89b2dfc700fcdc04b2eb493db5#diff-fecb83dcbbe516d8a2fb7c32d7e68a89
