### PR TITLE
Faster screenshots

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -606,7 +606,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     // Time for volume and power to be pressed to take a screenshot
     private static final long SCREENSHOT_CHORD_DELAY_TIMER = 0;
     // Increase the chord delay when taking a screenshot from the keyguard
-    private static final float KEYGUARD_SCREENSHOT_CHORD_DELAY_MULTIPLIER = 2.5f;
+    private static final float KEYGUARD_SCREENSHOT_CHORD_DELAY_MULTIPLIER = 1.5f;
     private boolean mScreenshotChordEnabled;
     private boolean mScreenshotChordVolumeDownKeyTriggered;
     private long mScreenshotChordVolumeDownKeyTime;

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -603,6 +603,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     // Screenshot trigger states
     // Time to volume and power must be pressed within this interval of each other.
     private static final long SCREENSHOT_CHORD_DEBOUNCE_DELAY_MILLIS = 150;
+    // Time for volume and power to be pressed to take a screenshot
+    private static final long SCREENSHOT_CHORD_DELAY_TIMER = 0;
     // Increase the chord delay when taking a screenshot from the keyguard
     private static final float KEYGUARD_SCREENSHOT_CHORD_DELAY_MULTIPLIER = 2.5f;
     private boolean mScreenshotChordEnabled;
@@ -1554,7 +1556,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             return (long) (KEYGUARD_SCREENSHOT_CHORD_DELAY_MULTIPLIER *
                     ViewConfiguration.get(mContext).getScreenshotChordKeyTimeout());
         }
-        return ViewConfiguration.get(mContext).getScreenshotChordKeyTimeout();
+        return SCREENSHOT_CHORD_DELAY_TIMER;
     }
 
     private long getRingerToggleChordDelay() {


### PR DESCRIPTION
This way you don't have to wait after pressing the combination.
On lockscreen, delay multiplier is set to 1.5f (I was noticing that it was slow on lockscreen, although I thought this couldn't be possible because of the other value being set to 0)

Test this for yourself and see if it is an improvement for you.

The reason for the screenshot delay on lockscreen is probably to avoid accidental screenshots when taking the phone out of the pocket etc.