### PR TITLE
Several fixes for brightness and FOD

### DIFF
--- a/core/res/res/values/aosip_config.xml
+++ b/core/res/res/values/aosip_config.xml
@@ -116,4 +116,7 @@
     <!-- Whether device supports internal audio recording -->
     <bool name="config_hasInternalAudioRecordingSupport">true</bool>
 
+    <!-- Whether to use scaled brightness (set -1 to disable) -->
+    <integer name="config_useScaleBrightness">-1</integer>
+
 </resources>

--- a/core/res/res/values/aosip_symbols.xml
+++ b/core/res/res/values/aosip_symbols.xml
@@ -178,4 +178,7 @@
   <!-- Whether device supports internal audio recording -->
   <java-symbol type="bool" name="config_hasInternalAudioRecordingSupport" />
 
+  <!-- Whether to use scaled brightness (set -1 to disable) -->
+  <java-symbol type="integer" name="config_useScaleBrightness" />
+
 </resources>

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -227,6 +227,7 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
     private boolean mSecureCameraLaunched;
     @VisibleForTesting
     protected boolean mTelephonyCapable;
+    protected boolean mPulsing;
 
     // Device provisioning state
     private boolean mDeviceProvisioned;
@@ -2350,6 +2351,7 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
         callback.onClockVisibilityChanged();
         callback.onKeyguardVisibilityChangedRaw(mKeyguardIsVisible);
         callback.onTelephonyCapable(mTelephonyCapable);
+        callback.onPulsing(mPulsing);
         for (Entry<Integer, SimData> data : mSimDatas.entrySet()) {
             final SimData state = data.getValue();
             callback.onSimStateChanged(state.subId, state.slotId, state.simState);
@@ -2692,5 +2694,16 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
             pw.println("    enabledByUser=" + mFaceSettingEnabledForUser.get(userId));
             pw.println("    mSecureCameraLaunched=" + mSecureCameraLaunched);
         }
+    }
+
+    public boolean setPulsing(boolean pulsing) {
+        mPulsing = pulsing;
+        for (int i = 0; i < mCallbacks.size(); i++) {
+            KeyguardUpdateMonitorCallback cb = mCallbacks.get(i).get();
+            if (cb != null) {
+                cb.onPulsing(mPulsing);
+            }
+        }
+        return mPulsing;
     }
 }

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitorCallback.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitorCallback.java
@@ -319,4 +319,8 @@ public class KeyguardUpdateMonitorCallback {
      */
     public void onBiometricsCleared() { }
 
+    /**
+     * Called when a pulsing is received.
+     */
+    public void onPulsing(boolean pulsing) { }
 }

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -25,6 +25,7 @@ import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.Point;
 import android.hardware.biometrics.BiometricSourceType;
+import android.hardware.display.DisplayManager;
 import android.os.Handler;
 import android.os.IHwBinder;
 import android.os.Looper;
@@ -62,6 +63,7 @@ public class FODCircleView extends ImageView implements OnTouchListener {
     private final Paint mPaintShow = new Paint();
     private final WindowManager.LayoutParams mParams = new WindowManager.LayoutParams();
     private final WindowManager mWindowManager;
+    private final DisplayManager mDisplayManager;
 
     private IFingerprintInscreen mFingerprintInscreenDaemon;
 
@@ -250,6 +252,7 @@ public class FODCircleView extends ImageView implements OnTouchListener {
 
         mUpdateMonitor = KeyguardUpdateMonitor.getInstance(context);
         mUpdateMonitor.registerCallback(mMonitorCallback);
+        mDisplayManager = context.getSystemService(DisplayManager.class);
     }
 
     @Override
@@ -488,12 +491,12 @@ public class FODCircleView extends ImageView implements OnTouchListener {
             }
 
             if (mShouldBoostBrightness) {
-                mParams.screenBrightness = 1.0f;
+                mDisplayManager.setTemporaryBrightness(255);
             }
 
             mParams.dimAmount = ((float) dimAmount) / 255.0f;
         } else {
-            mParams.screenBrightness = 0.0f;
+            mDisplayManager.setTemporaryBrightness(-1);
             mParams.dimAmount = 0.0f;
         }
 

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -67,7 +67,6 @@ public class FODCircleView extends ImageView implements OnTouchListener {
 
     private IFingerprintInscreen mFingerprintInscreenDaemon;
 
-    private int mDreamingOffsetX;
     private int mDreamingOffsetY;
     private int mNavigationBarSize;
 
@@ -466,7 +465,6 @@ public class FODCircleView extends ImageView implements OnTouchListener {
         }
 
         if (mIsDreaming) {
-            mParams.x += mDreamingOffsetX;
             mParams.y += mDreamingOffsetY;
         }
 
@@ -513,16 +511,8 @@ public class FODCircleView extends ImageView implements OnTouchListener {
             // It is fine to modify the variables here because
             // no other thread will be modifying it
             long now = System.currentTimeMillis() / 1000 / 60;
-            mDreamingOffsetX = (int) (now % (mDreamingMaxOffset * 4));
-            if (mDreamingOffsetX > mDreamingMaxOffset * 2) {
-                mDreamingOffsetX = mDreamingMaxOffset * 4 - mDreamingOffsetX;
-            }
             // Let y to be not synchronized with x, so that we get maximum movement
             mDreamingOffsetY = (int) ((now + mDreamingMaxOffset / 3) % (mDreamingMaxOffset * 2));
-            if (mDreamingOffsetY > mDreamingMaxOffset * 2) {
-                mDreamingOffsetY = mDreamingMaxOffset * 4 - mDreamingOffsetY;
-            }
-            mDreamingOffsetX -= mDreamingMaxOffset;
             mDreamingOffsetY -= mDreamingMaxOffset;
             if (mIsViewAdded) {
                 mHandler.post(() -> resetPosition());

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -76,7 +76,6 @@ public class FODCircleView extends ImageView implements OnTouchListener {
     private boolean mIsPulsing;
     private boolean mIsScreenOn;
     private boolean mIsViewAdded;
-    private boolean mIsRemoving;
 
     private Handler mHandler;
 
@@ -123,11 +122,20 @@ public class FODCircleView extends ImageView implements OnTouchListener {
             } else if (mBurnInProtectionTimer != null) {
                 mBurnInProtectionTimer.cancel();
             }
-
             if (mIsViewAdded) {
                 resetPosition();
                 invalidate();
             }
+        }
+
+        @Override
+        public void onPulsing(boolean pulsing) {
+            super.onPulsing(pulsing);
+            mIsPulsing = pulsing;
+            if (mIsPulsing) {
+                mIsDreaming = false;
+            }
+            mIsInsideCircle = false;
         }
 
         @Override
@@ -262,7 +270,7 @@ public class FODCircleView extends ImageView implements OnTouchListener {
         // the HAL is expected (if supported) to set the screen brightness
         // to maximum / minimum immediately when called
         if (mIsInsideCircle) {
-            if (mIsDreaming) {
+            if (mIsDreaming || mIsPulsing) {
                 setAlpha(1.0f);
             }
             if (!mIsPressed) {
@@ -277,7 +285,7 @@ public class FODCircleView extends ImageView implements OnTouchListener {
                 mIsPressed = true;
             }
         } else {
-            setAlpha(mIsDreaming ? 0.5f : 1.0f);
+            setAlpha(mIsDreaming ? (mIsPulsing ? 1.0f : 0.8f) : 1.0f);
             if (mIsPressed) {
                 IFingerprintInscreen daemon = getFingerprintInScreenDaemon();
                 if (daemon != null) {
@@ -288,11 +296,6 @@ public class FODCircleView extends ImageView implements OnTouchListener {
                     }
                 }
                 mIsPressed = false;
-            }
-
-            if (mIsRemoving) {
-                mIsRemoving = false;
-                mWindowManager.removeView(this);
             }
         }
     }
@@ -385,12 +388,6 @@ public class FODCircleView extends ImageView implements OnTouchListener {
     }
 
     public void show() {
-        if (mIsRemoving) {
-            // Last removal hasn't been finished yet
-            mIsRemoving = false;
-            mWindowManager.removeView(this);
-        }
-
         if (mIsViewAdded) {
             return;
         }
@@ -408,8 +405,9 @@ public class FODCircleView extends ImageView implements OnTouchListener {
         mParams.setTitle("Fingerprint on display");
         mParams.packageName = "android";
         mParams.type = WindowManager.LayoutParams.TYPE_VOLUME_OVERLAY;
-        mParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
+        mParams.flags = WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM |
                 WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH |
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL |
                 WindowManager.LayoutParams.FLAG_DIM_BEHIND |
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN;
         mParams.gravity = Gravity.TOP | Gravity.LEFT;
@@ -430,8 +428,8 @@ public class FODCircleView extends ImageView implements OnTouchListener {
 
         mIsInsideCircle = false;
         mIsViewAdded = false;
-        // Postpone removal to next re-layout to avoid blinking
-        mIsRemoving = true;
+        mWindowManager.removeView(this);
+        mIsPressed = false;
         setDim(false);
         invalidate();
     }

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -124,14 +124,8 @@ public class FODCircleView extends ImageView implements OnTouchListener {
             if (dreaming) {
                 mBurnInProtectionTimer = new Timer();
                 mBurnInProtectionTimer.schedule(new BurnInProtectionTask(), 0, 60 * 1000);
-                if (!mWakeLock.isHeld()) {
-                    mWakeLock.acquire();
-                }
             } else if (mBurnInProtectionTimer != null) {
                 mBurnInProtectionTimer.cancel();
-                if (mWakeLock.isHeld()) {
-                    mWakeLock.release();
-                }
             }
             if (mIsViewAdded) {
                 resetPosition();
@@ -284,6 +278,7 @@ public class FODCircleView extends ImageView implements OnTouchListener {
         // the HAL is expected (if supported) to set the screen brightness
         // to maximum / minimum immediately when called
         if (mIsInsideCircle) {
+          if (mIsDreaming) mWakeLock.acquire(300);
             if (mIsDreaming || mIsPulsing) {
                 setAlpha(1.0f);
             }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -4637,6 +4637,7 @@ public class StatusBar extends SystemUI implements DemoMode,
                     callback.onPulseStarted();
                     updateNotificationPanelTouchState();
                     setPulsing(true);
+                    KeyguardUpdateMonitor.getInstance(mContext).setPulsing(true);
                 }
 
                 @Override
@@ -4649,6 +4650,7 @@ public class StatusBar extends SystemUI implements DemoMode,
                         mStatusBarWindow.suppressWakeUpGesture(false);
                     }
                     setPulsing(false);
+                    KeyguardUpdateMonitor.getInstance(mContext).setPulsing(false);
                 }
 
                 private void setPulsing(boolean pulsing) {

--- a/services/core/java/com/android/server/lights/LightsService.java
+++ b/services/core/java/com/android/server/lights/LightsService.java
@@ -38,6 +38,7 @@ public class LightsService extends SystemService {
 
         private final IBinder mDisplayToken;
         private final int mSurfaceControlMaximumBrightness;
+        private final int mUseScaleBrightness;
 
         private LightImpl(Context context, int id) {
             mId = id;
@@ -55,6 +56,7 @@ public class LightsService extends SystemService {
                 }
             }
             mSurfaceControlMaximumBrightness = maximumBrightness;
+            mUseScaleBrightness = context.getResources().getInteger(com.android.internal.R.integer.config_useScaleBrightness);
         }
 
         @Override
@@ -87,9 +89,13 @@ public class LightsService extends SystemService {
                     SurfaceControl.setDisplayBrightness(mDisplayToken,
                             (float) brightness / mSurfaceControlMaximumBrightness);
                 } else {
-                    int color = brightness & 0x000000ff;
-                    color = 0xff000000 | (color << 16) | (color << 8) | color;
-                    setLightLocked(color, LIGHT_FLASH_NONE, 0, 0, brightnessMode);
+                    if (mUseScaleBrightness == -1){
+                        int color = brightness & 0x000000ff;
+                        color = 0xff000000 | (color << 16) | (color << 8) | color;
+                        setLightLocked(color, LIGHT_FLASH_NONE, 0, 0, brightnessMode);
+                    }else{
+                        setLightLocked(brightness * mUseScaleBrightness / 255, LIGHT_FLASH_NONE, 0, 0, brightnessMode);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Custom scaled brightness allow us especially for those who have max brightness over 255 to fix ridiculous backlight issues without having a custom light HAL.

And also there's several improvement and fixes for the in-display fingerprint such as :
- use inverted version of the wm's unfocusable flags (with respect to how this window interacts with the current method) to get better consistency
- allow displayManager to handle brightness of it
- partial wakelock added to keep the callbacks
- use pulsing callback to guards lighting and alpha changes to the icon

Honestly, I'm confused with these in-display fingerprint patches :disappointed:
But my in-display fingerprint finally works on ambient display enabled when I use those patches.
