### PR TITLE
Fix Doze auto-brightness issues on non-supported proximity sensor

### DIFF
--- a/packages/SystemUI/res/values/aosip_config.xml
+++ b/packages/SystemUI/res/values/aosip_config.xml
@@ -43,4 +43,8 @@
     <bool name="config_statusBarBurnInProtection">true</bool>
     <integer name="config_shift_interval">40</integer>
 
+    <!-- Whether the binned brightness sensor reports a value of 0 on proximity
+         near events -->
+    <bool name="doze_brightness_sensor_reports_proximity" translatable="false">true</bool>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
+++ b/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
@@ -175,6 +175,17 @@ public class DozeSensors {
         return null;
     }
 
+    static Sensor findBrightnessSensorForProximity(Context context, SensorManager sensorManager) {
+        boolean brightnessSensorReportsProximity =
+                context.getResources().getBoolean(R.bool.doze_brightness_sensor_reports_proximity);
+        if (brightnessSensorReportsProximity) {
+            return findSensorWithType(sensorManager,
+                    context.getString(R.string.doze_brightness_sensor_type));
+        }
+
+        return null;
+    }
+
     /**
      * If sensors should be registered and sending signals.
      */
@@ -297,8 +308,8 @@ public class DozeSensors {
 
             // The default prox sensor can be noisy, so let's use a prox gated brightness sensor
             // if available.
-            Sensor sensor = DozeSensors.findSensorWithType(mSensorManager,
-                    mContext.getString(R.string.doze_brightness_sensor_type));
+            Sensor sensor = DozeSensors.findBrightnessSensorForProximity(mContext,
+                    mSensorManager);
             mUsingBrightnessSensor = sensor != null;
             if (sensor == null) {
                 sensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);

--- a/packages/SystemUI/src/com/android/systemui/doze/DozeTriggers.java
+++ b/packages/SystemUI/src/com/android/systemui/doze/DozeTriggers.java
@@ -442,8 +442,7 @@ public class DozeTriggers implements DozeMachine.Part {
 
         public void check() {
             Preconditions.checkState(!mFinished && !mRegistered);
-            Sensor sensor = DozeSensors.findSensorWithType(mSensorManager,
-                    mContext.getString(R.string.doze_brightness_sensor_type));
+            Sensor sensor = DozeSensors.findBrightnessSensorForProximity(mContext, mSensorManager);
             mUsingBrightnessSensor = sensor != null;
             if (sensor == null) {
                 sensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);

--- a/packages/SystemUI/src/com/android/systemui/util/ProximitySensor.java
+++ b/packages/SystemUI/src/com/android/systemui/util/ProximitySensor.java
@@ -80,6 +80,11 @@ public class ProximitySensor {
     }
 
     private Sensor findBrightnessSensor(Context context, SensorManager sensorManager) {
+        boolean brightnessSensorReportsProximity =
+                context.getResources().getBoolean(R.bool.doze_brightness_sensor_reports_proximity);
+        if (!brightnessSensorReportsProximity) {
+            return null;
+        }
         String sensorType = context.getString(R.string.doze_brightness_sensor_type);
         List<Sensor> sensorList = sensorManager.getSensorList(Sensor.TYPE_ALL);
         Sensor sensor = null;


### PR DESCRIPTION
Some virtual proximity sensor like elliptic having a weird light state changes when auto brightness is used in ambient display.
This patch will allow us to change whether the binned brightness sensor reports a value of zero on proximity near events or not.
